### PR TITLE
Update Entry Submit to point at existing endpoint #48

### DIFF
--- a/src/pages/people/person/Timesheet.tsx
+++ b/src/pages/people/person/Timesheet.tsx
@@ -48,7 +48,7 @@ export function PersonWeeklyEntries(props: Props) {
       {[0, 1, 2, 3, 4, 5, 6].map( val =>
         <EntryDay
           date={currentDate.plus({'days': val})}
-          resource={resourceState.follow('search-sheet', { year: currentDate.year, weekNum: currentDate.weekNumber })}
+          resource={resourceState.follow('entry-collection')}
           personResource={props.resource}
           key={'day-' + val}
         />

--- a/src/pages/people/person/TimesheetEntry.tsx
+++ b/src/pages/people/person/TimesheetEntry.tsx
@@ -204,7 +204,7 @@ function EntryDayItemNew(props: EntryDayItemNewProps) {
   };
 
   const submit = async() => {
-    await props.parentResource.post({
+    await props.parentResource.postFollow({
       data: {
         ...data,
         _links: {


### PR DESCRIPTION
Resolves #48 

## Changes

- Changed the PersonWeeklyEntries in `/pages/people/person/Timesheet.tsx` to now follow 'entry-collection'
- Changed the `EntryDayItemNew` component to have the parent component `postFollow` instead of `post`

## Notes for PR

- If you try to submit a Entry without first selecting a Project, you will get a console error and the POST will not go through. There needs to be a follow up ticket for this
- When you decrease the size of the screen, you can no longer see the selected project 

## Screenshots

### Submitting without a selected project

<img width="1916" alt="Screen Shot 2022-10-20 at 12 53 54 PM" src="https://user-images.githubusercontent.com/31973147/197011094-9beb0426-9345-4876-8732-b4a9d32d0693.png">

### Minimized screen showing no selected project (even though there is) 

<img width="1816" alt="Screen Shot 2022-10-20 at 12 54 12 PM" src="https://user-images.githubusercontent.com/31973147/197011108-9f474089-5d90-445f-b6ae-1ac24c15d270.png">
