### PR TITLE
Improving the timesheet entry UI

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -18,6 +18,9 @@
 .confirm-modal button:not(:last-of-type) {
   margin-right: 2rem;
 }
+select.validationError {
+  box-shadow: 0 0 0 0.25rem red;
+}
 .material-icons,
 .material-icons-outlined {
   vertical-align: middle;

--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -19,7 +19,8 @@
   margin-right: 2rem;
 }
 select.validationError {
-  box-shadow: 0 0 0 0.25rem red;
+  box-shadow: 0 0 0 0.25rem var(--bs-red);
+  color: var(--bs-red);
 }
 .material-icons,
 .material-icons-outlined {

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -32,6 +32,7 @@ export function ConfirmModal(props: ConfirmModalProps) {
             : () => props.closeAction(false)
         }
         type='button'
+        autoFocus
       >
         {props.acceptLabel ? props.acceptLabel : 'Yes'}
       </button>

--- a/src/components/ProjectSelect.tsx
+++ b/src/components/ProjectSelect.tsx
@@ -39,7 +39,7 @@ export function ProjectSelect(props: Props) {
   const realValue = value ? client.go(value).uri : '';
 
   return <select {...passThrough} onChange={changeHandler} value={realValue}>
-    { showSelectProject ? <option key="empty" disabled value=''>Select Project</option> : null }
+    { showSelectProject ? <option key="empty" style={{display: 'none'}} disabled value=''>Select Project</option> : null }
     { items.map( item => <ProjectOption resource={item} key={item.uri} />) }
   </select>;
 }

--- a/src/pages/people/person/Timesheet.tsx
+++ b/src/pages/people/person/Timesheet.tsx
@@ -6,7 +6,7 @@ import { DateTime } from 'luxon';
 
 import { Person } from '@badgateway/tt-types';
 
-import { EntryDay } from './TimesheetEntry';
+import { TimesheetDay } from './TimesheetDay';
 
 type Props = {
   resource: Resource<Person>;
@@ -46,7 +46,7 @@ export function PersonWeeklyEntries(props: Props) {
     </ul>
     <div className="accordion">
       {[0, 1, 2, 3, 4, 5, 6].map( val =>
-        <EntryDay
+        <TimesheetDay
           date={currentDate.plus({'days': val})}
           resource={resourceState.follow('search-sheet', { year: currentDate.year, weekNum: currentDate.weekNumber })}
           personResource={props.resource}

--- a/src/pages/people/person/TimesheetDay.tsx
+++ b/src/pages/people/person/TimesheetDay.tsx
@@ -126,7 +126,7 @@ function EntryItem(props: EntryItemProps) {
       clearTimeout(delayedSubmitTimeout.current);
     }
 
-    delayedSubmitTimeout.current = setTimeout(() => submit(), 5000);
+    delayedSubmitTimeout.current = setTimeout(() => submit(), 1000);
   };
 
   const setDescription = (description: string) => {

--- a/src/pages/people/person/TimesheetDay.tsx
+++ b/src/pages/people/person/TimesheetDay.tsx
@@ -64,13 +64,13 @@ export function TimesheetDay(props: TimesheetDayProps) {
             </thead>
             <tbody>
               {items.map((item) => (
-                <EntryDayItem
+                <EntryItem
                   resource={item}
                   key={item.uri}
                   date={props.date}
                 />
               ))}
-              <EntryDayItemNew
+              <EntryItemNew
                 parentResource={props.resource}
                 date={props.date}
                 personResource={props.personResource}
@@ -84,11 +84,11 @@ export function TimesheetDay(props: TimesheetDayProps) {
   );
 }
 
-type EntryDayItemProps = {
+type EntryItemProps = {
   resource: Resource<Entry>;
   date: DateTime;
 };
-function EntryDayItem(props: EntryDayItemProps) {
+function EntryItem(props: EntryItemProps) {
   const {resourceState, setResourceState, loading, error, submit} =
     useResource<Entry>(props.resource);
 
@@ -208,13 +208,13 @@ function EntryDayItem(props: EntryDayItemProps) {
   );
 }
 
-type EntryDayItemNewProps = {
+type EntryItemNewProps = {
   parentResource: Resource;
   personResource: Resource<Person>;
   date: DateTime;
 };
 
-function EntryDayItemNew(props: EntryDayItemNewProps) {
+function EntryItemNew(props: EntryItemNewProps) {
   const [data, setData] = useState<EntryNew>({
     minutes: 60,
     description: '',

--- a/src/pages/people/person/TimesheetDay.tsx
+++ b/src/pages/people/person/TimesheetDay.tsx
@@ -9,13 +9,13 @@ import {Entry, EntryNew, Person} from '@badgateway/tt-types';
 
 import {ProjectSelect} from '../../../components/ProjectSelect';
 
-type DayProps = {
+type TimesheetDayProps = {
   resource: Resource;
   personResource: Resource<Person>;
   date: DateTime;
 };
 
-export function EntryDay(props: DayProps) {
+export function TimesheetDay(props: TimesheetDayProps) {
   const {items, loading, error} = useCollection<Entry>(props.resource, {
     refreshOnStale: true,
     rel: 'entry',

--- a/src/pages/people/person/TimesheetDay.tsx
+++ b/src/pages/people/person/TimesheetDay.tsx
@@ -153,7 +153,6 @@ function EntryItem(props: EntryItemProps) {
             value={resourceState.links.get('project')?.href}
             onChange={(projectHref) => setProject(projectHref)}
             className='form-control'
-            required
           />
         </td>
         <td>
@@ -314,7 +313,7 @@ function EntryItemNew(props: EntryItemNewProps) {
             <td>
               <button
                 type='button'
-                className='btn btn-primary'
+                className='btn btn-success'
                 onClick={() => submit()}
                 title='Save new entry'
               >

--- a/src/styles/core/_inputs.scss
+++ b/src/styles/core/_inputs.scss
@@ -1,3 +1,4 @@
 select.validationError {
-  box-shadow: 0 0 0 0.25rem red
+  box-shadow: 0 0 0 0.25rem var(--bs-red);
+  color: var(--bs-red)
 }

--- a/src/styles/core/_inputs.scss
+++ b/src/styles/core/_inputs.scss
@@ -1,0 +1,3 @@
+select.validationError {
+  box-shadow: 0 0 0 0.25rem red
+}

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -1,4 +1,5 @@
 @import './components/components.scss';
+@import './core/inputs.scss';
 @import './core/typography.scss';
 
 // clean/sort all this ↓ up when we impliment a design


### PR DESCRIPTION
### RE: [Improve time-entry ux to a point that it doesn't suck](https://github.com/badgateway/tt-app/issues/28), [Let the user know why their Entry was not submitted](https://github.com/badgateway/tt-app/issues/50)

Resolves #50.

This is part of an ongoing effort to make the timesheet view less suck.

## Summary of changes:
- File and component name changes
  - **TimesheetEntry.tsx → TimesheetDay.tsx** because the component is rendering the day, not a single the day's row/entry.
  - **EntryDay → TimesheetDay** to match file name.
  - **EntryDayItem → EntryItem** because this is just one row/entry, does not care about the day.
  - **EntryDayItem → EntryItemNew** because this is just one row/entry, does not care about the day.
- Reduce the delay for submit when editing an entry, from 5 seconds to 1 second.
- Change how the new entry creation renders, now hidden behind a button.
- Light validation for new entry, requiring a project to be selected and safeguarding the submit with a prompr alerting that no project has been chosen.
- Add `autoFocus` to the accept button for the ConfirmModal for easier keyboard dismiss.

| DEMO |
| --------- |
| ![demo](https://user-images.githubusercontent.com/52248161/198137717-a6097ed5-9fc6-4336-887d-9951dd7b8db8.gif) |

----
Feedback, nitpicks, and/or corrections encouraged. 🤖